### PR TITLE
add sentencepiece to pip requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ tqdm==4.64.1
 transformers==4.30.2
 einops==0.7.0
 prettytable==3.9.0
+sentencepiece==0.1.99


### PR DESCRIPTION
[sentencepiece](https://github.com/google/sentencepiece) is needed when `from pipeline.interface import get_model; model, tokenizer, processor = get_model(ckpt_path, use_bf16=True)`.
I added `sentencepiece` to pip requirements for LlamaTokenizer.